### PR TITLE
Absolute URL for /feed.xml redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "redirects": [
     {
       "source": "/feed.xml",
-      "destination": "/rss.xml",
+      "destination": "https://blog.alexo.dev/rss.xml",
       "permanent": true
     },
     {


### PR DESCRIPTION
Relative Location breaks strict RSS clients (e.g. TRMNL). 🤖 Generated with [Claude Code](https://claude.com/claude-code)