### PR TITLE
Fix host redirects: match trailing-slash paths and root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -35,15 +35,15 @@
   ],
   "redirects": [
     {
-      "source": "/:path*",
+      "source": "/:path(.*)",
       "has": [{ "type": "host", "value": "blog.alexo.dev" }],
-      "destination": "https://alexo.dev/:path*",
+      "destination": "https://alexo.dev/:path",
       "permanent": true
     },
     {
-      "source": "/:path*",
+      "source": "/:path(.*)",
       "has": [{ "type": "host", "value": "www.alexo.dev" }],
-      "destination": "https://alexo.dev/:path*",
+      "destination": "https://alexo.dev/:path",
       "permanent": true
     },
     {


### PR DESCRIPTION
/:path* does not match "/" or paths ending in "/" (Astro's canonical
URL style), so blog.alexo.dev/ and all page URLs were serving 200s
instead of redirecting. /:path(.*) matches everything.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
