### PR TITLE
Rename "Posts" to "Blog" in nav, page title, and home button

### DIFF
--- a/src/i18n/lang/en.ts
+++ b/src/i18n/lang/en.ts
@@ -3,7 +3,7 @@ import type { UIStrings } from "../types";
 export default {
   nav: {
     home: "Home",
-    posts: "Posts",
+    posts: "Blog",
     speaking: "Speaking",
     projects: "Projects",
     tags: "Tags",
@@ -46,7 +46,7 @@ export default {
     tagsTitle: "Tags",
     tagsDesc: "All the tags used in posts.",
 
-    postsTitle: "Posts",
+    postsTitle: "Blog",
     postsDesc: "All the articles I've posted.",
 
     archivesTitle: "Archives",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const homePath = getRelativeLocaleUrl(locale, "");
 const linkButtons = [
   { label: "🎤 Speaking", href: "/speaking/" },
   { label: "💻 Projects", href: "/projects/" },
-  { label: "💬 Posts", href: "/posts/" },
+  { label: "💬 Blog", href: "/posts/" },
   { label: "📄 Resume", href: "/resume/" },
   { label: "🖋️ Fountain Pen Collection", href: "https://alexo-pens.notion.site/Alex-s-Fountain-Pen-Dashboard-268e3af9171080c4a7c2c8aca9b92a2e" },
 ];


### PR DESCRIPTION
URLs stay /posts/ — label change only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
