### PR TITLE
Update README for the unified site and new publishing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,78 @@
-# blog.alexo.dev
+# alexo.dev
 
-Alex's blog — random thoughts on programming, homelab, and productivity.
+Alex's whole web presence: link-in-bio home page, blog, speaker portfolio,
+project showcase, and resume.
 
 Built with [Astro](https://astro.build) ([AstroPaper](https://github.com/satnaing/astro-paper) theme)
-and [TinaCMS](https://tina.io), deployed on Vercel. Posts are plain markdown —
-**pushing to `main` publishes automatically.**
+and [TinaCMS](https://tina.io), deployed on Vercel. All content is plain markdown/YAML.
+`main` is branch-protected: **changes land via PR, and merging publishes automatically** (~2 min).
 
-## Writing a post (Obsidian workflow)
+## Writing a blog post (Obsidian workflow)
 
-1. Write the post in Obsidian as a normal markdown note.
-2. Add this front matter at the top (make it an Obsidian template for one-keystroke reuse):
+1. Draft in Obsidian. The `astro-blog-post` Templater template scaffolds the
+   front matter for you:
 
    ```yaml
    ---
    title: "My Post Title"
-   description: "One or two sentences — required, shows up in cards and SEO."
+   description: "One or two sentences. Required, shows up in cards and SEO."
    pubDatetime: 2026-06-11T12:00:00Z
    tags:
      - Programming
-   draft: false
+   draft: true
    ---
    ```
 
-3. Save/copy the file into `src/content/posts/` in this repo.
-   **The filename becomes the URL**: `my-cool-post.md` → `blog.alexo.dev/posts/my-cool-post/`
-   (use lowercase-with-hyphens).
-4. Images: drop them in `public/assets/uploads/<post-name>/` and reference them as
-   `![alt](/assets/uploads/<post-name>/pic.png)`.
-5. Publish:
+2. Use standard markdown only. No `[[wikilinks]]` or `![[image]]` embeds.
+   (The Obsidian *Markdown Export* plugin converts embeds and pulls attachments
+   into the repo if you point its output at `src/content/posts`.)
+3. Move it into the site:
 
    ```bash
-   git add . && git commit -m "Post: my cool post" && git push
+   ./scripts/publish.sh ~/path/to/vault/blog/posts/my-draft.md --publish --pr
    ```
 
-   Vercel builds and deploys in ~2 minutes. Done.
+   This strips any date prefix off the filename (**the filename becomes the URL**:
+   `my-cool-post.md` → `alexo.dev/posts/my-cool-post/`), copies referenced images
+   into `public/assets/uploads/<slug>/`, rewrites their paths, and warns about
+   anything Astro can't render. `--publish` flips `draft: false` and bumps the
+   date; `--pr` opens the pull request for you. Merge it and you're live.
+
+   To run it from outside the repo, set the env var once per machine:
+
+   ```bash
+   export BLOG_REPO="$HOME/coding/alexo-website/blog.alexo.dev"
+   ```
 
 Tips:
-- Not ready to publish? Set `draft: true` (or prefix the filename with `_`).
-- The [Obsidian Git plugin](https://github.com/Vinzent03/obsidian-git) can automate
-  step 5 if your vault folder is (or contains) this repo.
+- Not ready to publish? Keep `draft: true` (or prefix the filename with `_`).
+- Images by hand: `public/assets/uploads/<slug>/pic.png`, referenced as
+  `![alt](/assets/uploads/<slug>/pic.png)`.
+
+## Scaffolding new content
+
+`./scripts/new.sh` creates correctly-shaped files for any content type
+(prompts for anything you don't pass as a flag):
+
+```bash
+./scripts/new.sh post     # draft post in src/content/posts/
+./scripts/new.sh project  # project card in src/content/projects/
+./scripts/new.sh talk     # speaking engagement added to src/data/speaking.yaml
+```
 
 ## Other ways to publish
 
-- **Tina editor**: blog.alexo.dev/admin — visual editing in the browser from any device;
-  saves commit straight to the repo.
-- **GitHub web editor**: edit/create files in `src/content/posts/` directly on github.com.
+- **Tina editor**: [alexo.dev/admin](https://alexo.dev/admin) — visual editing in
+  the browser from any device; saves commit straight to the repo.
+- **GitHub web editor**: edit/create files in `src/content/` directly on github.com.
 
 ## Local development
 
 ```bash
-asdf install      # Node 24
+asdf install        # Node 24
 yarn install
-yarn dev          # localhost:4321 (+ /admin)
+pre-commit install  # gitleaks + hygiene hooks (one-time)
+yarn dev            # localhost:4321 (+ /admin)
 ```
 
 See `CLAUDE.md` for architecture notes and build gotchas.


### PR DESCRIPTION
- alexo.dev (not blog.alexo.dev), all five sections of the site
- PR-based publishing (main is branch-protected now)
- Obsidian workflow rewritten around scripts/publish.sh + the
  Markdown Export plugin, with the BLOG_REPO env var
- Document scripts/new.sh scaffolding and pre-commit install

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
