### PR TITLE
RSS: add atom:link rel=self; redirect feeds.alexo.dev root to alexo.dev

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -12,6 +12,8 @@ export async function GET() {
     title: config.site.title,
     description: config.site.description,
     site: config.site.url,
+    xmlns: { atom: "http://www.w3.org/2005/Atom" },
+    customData: `<atom:link href="${new URL("rss.xml", config.site.url).href}" rel="self" type="application/rss+xml"/>`,
     items: sortedPosts.map(({ data, id, filePath }) => ({
       link: getPostUrl(id, filePath, config.site.lang),
       title: data.title,

--- a/vercel.json
+++ b/vercel.json
@@ -47,6 +47,12 @@
       "permanent": true
     },
     {
+      "source": "/",
+      "has": [{ "type": "host", "value": "feeds.alexo.dev" }],
+      "destination": "https://alexo.dev/",
+      "permanent": false
+    },
+    {
       "source": "/afrotech-2024",
       "destination": "/posts/afrotech-2024/",
       "permanent": true


### PR DESCRIPTION
- atom:link self-reference (W3C validator interoperability suggestion)
- feeds.alexo.dev exists only for feed readers; its homepage now 307s
  to alexo.dev so humans land on the canonical host

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
