### PR TITLE
blog.alexo.dev root now redirects to /posts/ instead of the home page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -35,6 +35,12 @@
   ],
   "redirects": [
     {
+      "source": "/",
+      "has": [{ "type": "host", "value": "blog.alexo.dev" }],
+      "destination": "https://alexo.dev/posts/",
+      "permanent": true
+    },
+    {
       "source": "/:path(.*)",
       "has": [{ "type": "host", "value": "blog.alexo.dev" }],
       "destination": "https://alexo.dev/:path",


### PR DESCRIPTION
The old blog home was the post list; path-preserving alone sent those
visitors to the link-in-bio home. Deeper blog paths still map 1:1.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
